### PR TITLE
Support legacy panel with videoBuiltin

### DIFF
--- a/BrightnessKeys/BrightnessKeys.cpp
+++ b/BrightnessKeys/BrightnessKeys.cpp
@@ -95,6 +95,11 @@ void BrightnessKeys::getBrightnessPanel() {
         _panel = getAcpiDevice(getDeviceByAddress(info->videoBuiltin, kIOACPILCDPanel, kIOACPIDisplayTypeMask));
         
         //
+        // On some laptops, like AMD laptops, the panel can be of legacy type.
+        //
+        _panel = getAcpiDevice(getDeviceByAddress(info->videoBuiltin, kIOACPILegacyPanel));
+
+        //
         // On some newer laptops, address of Display Output Device (DOD)
         // may not export panel information. We can verify it by whether
         // a DOD of CRT type present, which should present when types are

--- a/BrightnessKeys/BrightnessKeys.cpp
+++ b/BrightnessKeys/BrightnessKeys.cpp
@@ -97,7 +97,7 @@ void BrightnessKeys::getBrightnessPanel() {
         //
         // On some laptops, like AMD laptops, the panel can be of legacy type.
         //
-        _panel = getAcpiDevice(getDeviceByAddress(info->videoBuiltin, kIOACPILegacyPanel));
+        if (_panel == nullptr) { _panel = getAcpiDevice(getDeviceByAddress(info->videoBuiltin, kIOACPILegacyPanel)); }
 
         //
         // On some newer laptops, address of Display Output Device (DOD)


### PR DESCRIPTION
Some laptops, like AMD laptops, have _UID set to kIOACPILegacyPanel